### PR TITLE
获取属性集实例时，将搜索字段转为小写

### DIFF
--- a/java/Dddml.Wms.JavaServices/src/main/java/org/dddml/wms/domain/service/AttributeSetInstanceStateJsonObjectMapper.java
+++ b/java/Dddml.Wms.JavaServices/src/main/java/org/dddml/wms/domain/service/AttributeSetInstanceStateJsonObjectMapper.java
@@ -69,6 +69,10 @@ public class AttributeSetInstanceStateJsonObjectMapper extends AbstractDynamicOb
         Map<String, String> maps = attributeSetService.
                 getPropertyExtensionFieldDictionary(state.getAttributeSetId());
         maps.forEach((name, fieldName) -> {
+        	//fieldName开头首字母转小写
+        	  if (Character.isUpperCase(fieldName.charAt(0))) {
+        		  fieldName = Character.toLowerCase(fieldName.charAt(0)) + fieldName.substring(1);
+              }
             //FIXME 这里应该判断fields是否为空，并且判断 name 是否位于 fields 中
             try {
                 /**这里还是自己重写吧，没有必要引进一个库，直接使用 JDK 的内省读写*/


### PR DESCRIPTION
获取属性集实例时，将搜索字段转为小写， name貌似就是根据attributeId 获取的，但是还是存在一个异常待修复，查询实例会带出    属性名   和 实例值（比如查询颜色这个属性是这样  "RgbColor": "红","RGB Color": "红"）